### PR TITLE
bugfix for invalid connectorname, fix not getting master.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC      ?= gcc
-CFLAGS  ?= -pedantic -Wall -I /usr/include/drm
+CFLAGS  ?= -O0 -ggdb -pedantic -Wall -I /usr/include/libdrm
 LDFLAGS ?= -ldrm
 
 OBJ = main.o framebuffer.o

--- a/framebuffer.c
+++ b/framebuffer.c
@@ -105,6 +105,7 @@ int get_framebuffer(const char *dri_device, const char *connector_name, struct f
                 break;
 
         drmModeFreeConnector(connector);
+        connector = 0;
     }
 
     if (!connector) {
@@ -115,9 +116,10 @@ int get_framebuffer(const char *dri_device, const char *connector_name, struct f
     /* Get the preferred resolution */
     drmModeModeInfoPtr resolution = 0;
     for (int i = 0; i < connector->count_modes; i++) {
-            resolution = &connector->modes[i];
-            if (resolution->type & DRM_MODE_TYPE_PREFERRED)
-                    break;
+            drmModeModeInfoPtr res = 0;
+            res = &connector->modes[i];
+            if (res->type & DRM_MODE_TYPE_PREFERRED)
+                    resolution = res;
     }
 
     if (!resolution) {

--- a/framebuffer.h
+++ b/framebuffer.h
@@ -3,8 +3,8 @@
 
 #include <stdint.h>
 
-#include <drm/drm.h>
-#include <drm/drm_mode.h>
+#include <libdrm/drm.h>
+#include <libdrm/drm_mode.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 


### PR DESCRIPTION
There was a bug when looking for the connector name. When not matching any, the code would take the last checked.

Also, the allocating of the DRM master role was not checked.

Allowed the stdin to send EOF before filling up all the buffer.

Changed include paths to match (more recent?) paths libdrm/...

Signed-off-by: Achim <awlutmkaf@hotmail.com>