### PR TITLE
Do not use uninitialized data. Fixes crash. (issue #2)

### DIFF
--- a/main.c
+++ b/main.c
@@ -272,6 +272,7 @@ int main(int argc, char** argv)
     }
 
     struct framebuffer fb;
+    memset(&fb, 0, sizeof(fb));
     ret = 1;
     if (get_framebuffer(dri_device, connector, &fb) == 0) {
         if(!fill_framebuffer_from_stdin(&fb))


### PR DESCRIPTION
Uninitialized data on the stack is used, causing a crash.
This will fix it by making sure fb members are 0.
This fixes #2 issue.